### PR TITLE
CacheManager configuration override fix

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -105,7 +105,7 @@ class CacheManager
      */
     protected function setConfiguration(array $configuration)
     {
-        $this->config = array_merge($configuration, $this->config);
+        $this->config = array_merge($this->config, $configuration);
     }
 
     /**

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -3,9 +3,9 @@
 namespace Kaperys\Financial\Cache;
 
 use Kaperys\Financial\Cache\Exception\CacheConfigurationException;
+use Kaperys\Financial\Cache\Exception\CacheFileNotFoundException;
 use Kaperys\Financial\Cache\Exception\CacheWriterException;
 use Kaperys\Financial\Message\Schema\MessageSchemaInterface;
-use Kaperys\Financial\Cache\Exception\CacheFileNotFoundException;
 use ReflectionClass;
 use zpt\anno\Annotations;
 
@@ -18,7 +18,6 @@ use zpt\anno\Annotations;
  */
 class CacheManager
 {
-
     // The message schema cache file name
     const CACHED_SCHEMA_FILE_NAME = 'schema.json';
 
@@ -58,10 +57,16 @@ class CacheManager
             $schemaPropertyAnnotations[] = $propertyAnnotations;
         }
 
-        $cachePath = $this->getConfiguration('cacheDirectory') . DIRECTORY_SEPARATOR .
-            $schemaClass->getName() . DIRECTORY_SEPARATOR . self::CACHED_SCHEMA_FILE_NAME;
+        $cachePath = $this->getConfiguration('cacheDirectory') . DIRECTORY_SEPARATOR . $schemaClass->getName();
 
-        if (!file_put_contents($cachePath, json_encode($schemaPropertyAnnotations))) {
+        if (!is_dir($cachePath)) {
+            mkdir($cachePath, 0777, true);
+        }
+
+        if (!file_put_contents(
+            $cachePath . DIRECTORY_SEPARATOR . self::CACHED_SCHEMA_FILE_NAME,
+            json_encode($schemaPropertyAnnotations)
+        )) {
             throw new CacheWriterException('Cannot write cache file: ' . $cachePath);
         }
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kaperys\Financial\Tests\Cache;
+
+use Kaperys\Financial\Cache\CacheManager;
+use PHPUnit\Framework\TestCase;
+
+class CacheManagerTest extends TestCase
+{
+    /** @test */
+    public function configureCacheDirectory()
+    {
+        $cacheManager = new CacheManager([
+            'cacheDirectory' => '/test/cache/dir',
+        ]);
+
+        $reflection = new \ReflectionClass($cacheManager);
+        $method = $reflection->getMethod('getConfiguration');
+        $method->setAccessible(true);
+
+        $this->assertEquals('/test/cache/dir', $method->invoke($cacheManager, 'cacheDirectory'));
+    }
+
+}

--- a/tests/FinancialTest.php
+++ b/tests/FinancialTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\TestCase;
  */
 class FinancialTest extends TestCase
 {
-
     const DUMMY_MTI           = '0200';
     const DUMMY_PAN           = '1029384756193749';
     const DUMMY_HEADER_LENGTH = 2;
@@ -27,11 +26,7 @@ class FinancialTest extends TestCase
     /** @test */
     public function pack()
     {
-        $cacheManager = new CacheManager(
-            [
-                'cacheDirectory' => '../fixtures/schema.json'
-            ]
-        );
+        $cacheManager = new CacheManager();
 
         /** @var ISO8583 $schemaManager */
         $schemaManager = new SchemaManager(new ISO8583(), $cacheManager);
@@ -56,11 +51,7 @@ class FinancialTest extends TestCase
     /** @test */
     public function unpack()
     {
-        $cacheManager = new CacheManager(
-            [
-                'cacheDirectory' => '../fixtures/schema.json'
-            ]
-        );
+        $cacheManager = new CacheManager();
 
         /** @var ISO8583 $schemaManager */
         $schemaManager = new SchemaManager(new ISO8583(), $cacheManager);


### PR DESCRIPTION
When trying to override the configuration for the `CacheManager` the settings are ineffective due to a parameter ordering issue within `CacheManager::setConfiguration(array $configuration)`. This PR fixes this bug.

(This PR also contains another small change regarding the cache directory which made the tests fail with a new install.)